### PR TITLE
Adds script to create nuget package

### DIFF
--- a/nugetPackage.bat
+++ b/nugetPackage.bat
@@ -1,0 +1,4 @@
+echo %APPVEYOR_BUILD_NUMBER%
+powershell -Command "(gc src/project.json) -replace '.0-\*', '.%APPVEYOR_BUILD_NUMBER%-*' | Out-File src/project.json"
+
+dotnet pack src --configuration Release --output src/NuGet --version-suffix "alpha"


### PR DESCRIPTION
Do we want to publish this as an alpha? I have it because we are using the alpha version of Nancy2.

To get this to work on AppVeyor:
You can fix this by adding this command to the 'After Build Script' actions: "nugetPackage.bat"
On the same page you should also disable the automatic packaging of nuget packages.
You will then need to specify to AppVeyor where the new package is. On the Artifacts page, add this path: "**\src\*.nupkg"