### PR TITLE
Creates more options for configurations

### DIFF
--- a/demos/Cimpress.Nancy.Demo/DemoNancyServiceBootstrapper.cs
+++ b/demos/Cimpress.Nancy.Demo/DemoNancyServiceBootstrapper.cs
@@ -1,14 +1,21 @@
 ﻿using Cimpress.Nancy.Components;
+using Cimpress.Nancy.Config;
+using Microsoft.Extensions.Configuration;
 using Nancy.Bootstrapper;
 using Nancy.TinyIoc;
+using IConfiguration = Cimpress.Nancy.Config.IConfiguration;
 
 namespace Cimpress.Nancy.Demo
 {
     public class DemoNancyServiceBootstrapper : NancyServiceBootstrapper
     {
-        public DemoNancyServiceBootstrapper() : base()
+        private readonly IConfiguration _configuration = new Configuration();
+
+        public DemoNancyServiceBootstrapper(Microsoft.Extensions.Configuration.IConfiguration aspNetConfig) : base()
         {
-            
+            // We want to load the configuration info from the application settings.
+            // This will bind the object from the section "Cimpress.Nancy"
+            aspNetConfig.GetSection("Cimpress.Nancy").Bind(_configuration);
         }
 
         protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
@@ -23,6 +30,10 @@ namespace Cimpress.Nancy.Demo
             // should only wire up the specified implementations
             container.Register<IVersionModuleExtender, DemoModuleExtender>();
             container.Register<IBootstrapperExtender, DemoBootstrapperExtender>();
+
+            // Register the Cimpress.Nancy configuration object
+            container.Register(_configuration);
+
             base.ApplicationStartup(container, pipelines);
         }
     }

--- a/demos/Cimpress.Nancy.Demo/Startup.cs
+++ b/demos/Cimpress.Nancy.Demo/Startup.cs
@@ -37,7 +37,10 @@ namespace Cimpress.Nancy.Demo
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseOwin(x => x.UseNancy());
+            app.UseOwin(x => x.UseNancy(new NancyOptions
+            {
+                Bootstrapper = new DemoNancyServiceBootstrapper(Configuration)
+            }));
         }
     }
 }

--- a/demos/Cimpress.Nancy.Demo/appsettings.json
+++ b/demos/Cimpress.Nancy.Demo/appsettings.json
@@ -6,5 +6,11 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "Cimpress.Nancy": {
+    "Version": "v25",
+    "OptionalParameters": {
+      "TestParam":  "Testing"
+    }
   }
 }

--- a/demos/Cimpress.Nancy.Swagger.Demo/DemoNancyServiceBootstrapper.cs
+++ b/demos/Cimpress.Nancy.Swagger.Demo/DemoNancyServiceBootstrapper.cs
@@ -4,6 +4,7 @@ using Nancy.Bootstrapper;
 using Nancy.TinyIoc;
 using Cimpress.Nancy.Swagger;
 using Nancy.Swagger.Services;
+using Cimpress.Nancy.Config;
 
 namespace Cimpress.Nancy.Swagger.Demo
 {

--- a/src/Cimpress.Nancy.Swagger/SwaggerModule.cs
+++ b/src/Cimpress.Nancy.Swagger/SwaggerModule.cs
@@ -1,4 +1,5 @@
-﻿using Nancy;
+﻿using Cimpress.Nancy.Config;
+using Nancy;
 
 namespace Cimpress.Nancy.Swagger
 {

--- a/src/Cimpress.Nancy/Config/Configuration.cs
+++ b/src/Cimpress.Nancy/Config/Configuration.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace Cimpress.Nancy
+namespace Cimpress.Nancy.Config
 {
     public class Configuration : IConfiguration
     {
         public string Version { get; set; }
-        public IDictionary<string, string> OptionalParameters { get; set; } 
+        public Dictionary<string, string> OptionalParameters { get; set; } 
     }
 }

--- a/src/Cimpress.Nancy/Config/FileConfigurationLoader.cs
+++ b/src/Cimpress.Nancy/Config/FileConfigurationLoader.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Newtonsoft.Json;
+
+namespace Cimpress.Nancy.Config
+{
+    public class FileConfigurationLoader : IConfigurationLoader
+    {
+        private readonly string _configFilePath;
+
+        public FileConfigurationLoader(string configFilePath)
+        {
+            _configFilePath = configFilePath;
+        }
+
+        public Task<T> LoadConfiguration<T>() where T : IConfiguration
+        {
+            var configuration = GetConfigurationObject<T>();
+
+            if (configuration == null)
+            {
+                return Task.FromResult(default(T));
+            }
+
+            if (string.IsNullOrEmpty(configuration.Version))
+            {
+                configuration.Version = GetVersion();
+            }
+            return Task.FromResult(configuration);
+        }
+
+        public virtual string GetVersion()
+        {
+            return "v0";
+        }
+
+        private T GetConfigurationObject<T>() where T : IConfiguration
+        {
+            var configString = File.Exists(_configFilePath) ? File.ReadAllText(_configFilePath) : string.Empty;
+
+            if (string.IsNullOrEmpty(configString))
+            {
+                return default(T);
+            }
+
+            var config = JsonConvert.DeserializeObject<T>(configString);
+
+            if (config.OptionalParameters == null)
+            {
+                config.OptionalParameters = new Dictionary<string, string>();
+            }
+            return config;
+        }
+    }
+}

--- a/src/Cimpress.Nancy/Config/IConfiguration.cs
+++ b/src/Cimpress.Nancy/Config/IConfiguration.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 
-namespace Cimpress.Nancy
+namespace Cimpress.Nancy.Config
 {
     public interface IConfiguration
     {
         string Version { get; set; }
-        IDictionary<string, string> OptionalParameters { get; set; }
+        Dictionary<string, string> OptionalParameters { get; set; }
     }
 }

--- a/src/Cimpress.Nancy/Config/IConfigurationLoader.cs
+++ b/src/Cimpress.Nancy/Config/IConfigurationLoader.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace Cimpress.Nancy.Config
+{
+    public interface IConfigurationLoader
+    {
+        Task<T> LoadConfiguration<T>() where T : IConfiguration;
+        string GetVersion();
+    }
+}

--- a/src/Cimpress.Nancy/IConfigurationLoader.cs
+++ b/src/Cimpress.Nancy/IConfigurationLoader.cs
@@ -1,8 +1,0 @@
-﻿namespace Cimpress.Nancy
-{
-    public interface IConfigurationLoader
-    {
-        T LoadConfiguration<T>(T configuration) where T : IConfiguration;
-        string GetVersion();
-    }
-}

--- a/src/Cimpress.Nancy/Modules/VersionModule.cs
+++ b/src/Cimpress.Nancy/Modules/VersionModule.cs
@@ -1,4 +1,5 @@
 ﻿using Cimpress.Nancy.Components;
+using Cimpress.Nancy.Config;
 using Nancy;
 
 namespace Cimpress.Nancy.Modules


### PR DESCRIPTION
Addresses #15 

This refactors the configuration objects into their own folder/namespace and breaks up the previous configuration loading into two separate classes. 

Now there are at least 3 ways to load a configuration:
1) From a File
2) From S3 (S3 and AWS should probably be moved to a separate project called Cimpress.Nancy.AWS in a different PR)
3) Or from Microsoft's Configuration object. This method is demonstrated in the Nancy.Cimpress.Demo project. I figured out how to do this from this stackoverflow post: http://stackoverflow.com/questions/34991016/ioptions-not-working-with-tinyioc-nancyfx/35016934

I had to change the IDictionary in IConfiguration to Dictionary in order for method #3 to work. 
The reason why is dictated here: https://andrewlock.net/how-to-use-the-ioptions-pattern-for-configuration-in-asp-net-core-rc2/#dontexposeidictionary
The writer offers a bulky solution, I didn't want to implement it, especially since the problem seems like it's been resolved and the fix will be included in a later version of the configuration assembly.