### PR TITLE
Adds security example

### DIFF
--- a/Cimpress.Nancy.sln
+++ b/Cimpress.Nancy.sln
@@ -24,6 +24,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Nancy.Demo", "demo
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Nancy.Swagger.Demo", "demos\Cimpress.Nancy.Swagger.Demo\Cimpress.Nancy.Swagger.Demo.xproj", "{6B4F7DEC-301E-4A7D-9BA5-83FBDB6A7405}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Nancy.Security.Demo", "demos\Cimpress.Nancy.Security.Demo\Cimpress.Nancy.Security.Demo.xproj", "{45F8838F-F941-41C6-898B-F73C33874CCB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,6 +56,10 @@ Global
 		{6B4F7DEC-301E-4A7D-9BA5-83FBDB6A7405}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B4F7DEC-301E-4A7D-9BA5-83FBDB6A7405}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B4F7DEC-301E-4A7D-9BA5-83FBDB6A7405}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45F8838F-F941-41C6-898B-F73C33874CCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45F8838F-F941-41C6-898B-F73C33874CCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45F8838F-F941-41C6-898B-F73C33874CCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45F8838F-F941-41C6-898B-F73C33874CCB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,5 +71,6 @@ Global
 		{66872FFB-1CF1-41B4-8396-C8303DA8B6DE} = {D2487BB9-DF16-46EB-B693-6E17106AD43D}
 		{4ACA5CAB-84A8-4267-AE9F-92737153FE63} = {637D3174-8D80-432D-AF7E-8D385E8BCBEE}
 		{6B4F7DEC-301E-4A7D-9BA5-83FBDB6A7405} = {637D3174-8D80-432D-AF7E-8D385E8BCBEE}
+		{45F8838F-F941-41C6-898B-F73C33874CCB} = {637D3174-8D80-432D-AF7E-8D385E8BCBEE}
 	EndGlobalSection
 EndGlobal

--- a/demos/Cimpress.Nancy.Security.Demo/Cimpress.Nancy.Security.Demo.xproj
+++ b/demos/Cimpress.Nancy.Security.Demo/Cimpress.Nancy.Security.Demo.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>45f8838f-f941-41c6-898b-f73c33874ccb</ProjectGuid>
+    <RootNamespace>Cimpress.Nancy.Security.Demo</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/demos/Cimpress.Nancy.Security.Demo/DemoNancyServiceBootstrapper.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/DemoNancyServiceBootstrapper.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Cimpress.Nancy.Components;
+using Nancy.Bootstrapper;
+using Nancy.TinyIoc;
+using Cimpress.Nancy.Config;
+
+namespace Cimpress.Nancy.Security.Demo
+{
+    public class DemoNancyServiceBootstrapper : NancyServiceBootstrapper
+    {
+        public DemoNancyServiceBootstrapper() : base()
+        {
+        }
+
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            IConfiguration configuration = new Configuration();
+            configuration.OptionalParameters = new Dictionary<string, string>
+            {
+                ["OAuth2Issuer"] = "[Pass root url of issuer here]",
+                ["OAuth2SecretKey"] = "[Pass application's secret key here]",
+                ["OAuth2ClientId"] = "[Pass application's client id here]"
+            };
+            container.Register(configuration);
+            base.ApplicationStartup(container, pipelines);
+        }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Modules/DemoModule.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Modules/DemoModule.cs
@@ -1,0 +1,14 @@
+﻿using Cimpress.Nancy.Components;
+using Cimpress.Nancy.Modules;
+using Nancy;
+
+namespace Cimpress.Nancy.Security.Demo.Modules
+{
+    public class DemoModule : VersionModule
+    {
+        public DemoModule(IComponentManager componentManager) : base(string.Empty, "/demo", componentManager)
+        {
+            Get("/", _ => HttpStatusCode.OK, null, "Demo");
+        }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Program.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Program.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Cimpress.Nancy.Security.Demo
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Properties/launchSettings.json
+++ b/demos/Cimpress.Nancy.Security.Demo/Properties/launchSettings.json
@@ -1,0 +1,26 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:43304/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Cimpress.Nancy.Demo": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Security/AuthValidator.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Security/AuthValidator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Cimpress.Nancy.Components;
+using Cimpress.Nancy.Config;
+
+namespace Cimpress.Nancy.Security.Demo.Security
+{
+    public class AuthValidator : OAuth2Validator
+    {
+        public AuthValidator(INancyLogger log, IConfiguration config) : base(log)
+        {
+            OAuth2Issuer = config.OptionalParameters["OAuth2Issuer"];
+            OAuthSecretKey = config.OptionalParameters["OAuth2SecretKey"];
+            OAuth2ClientId = config.OptionalParameters["OAuth2ClientId"];
+        }
+
+        public override string OAuth2Issuer { get; }
+        public override string OAuthSecretKey { get; }
+        public override string OAuth2ClientId { get; }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Security/AuthVerifier.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Security/AuthVerifier.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Cimpress.Nancy.Config;
+
+namespace Cimpress.Nancy.Security.Demo.Security
+{
+    public class AuthVerifier : Nancy.Security.AuthVerifier
+    {
+        public AuthVerifier(IConfiguration config)
+        {
+            AuthHeader = config.OptionalParameters["OAuth2ClientId"];
+        }
+
+        public override string AuthHeader { get; }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/Startup.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Startup.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Nancy.Owin;
+
+namespace Cimpress.Nancy.Security.Demo
+{
+    public class Startup
+    {
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+            Configuration = builder.Build();
+        }
+
+        public IConfigurationRoot Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            // Add framework services.
+            services.AddMvc();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseOwin(x => x.UseNancy());
+        }
+    }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/appsettings.json
+++ b/demos/Cimpress.Nancy.Security.Demo/appsettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/project.json
+++ b/demos/Cimpress.Nancy.Security.Demo/project.json
@@ -1,0 +1,71 @@
+{
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0",
+    "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Owin": "1.1.0",
+    "log4net": "2.0.7",
+    "Nancy": "2.0.0-clinteastwood",
+    "Cimpress.Nancy": {
+      "target": "project"
+    },
+    "Cimpress.Nancy.Security": {
+      "target": "project"
+    }
+  },
+
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.1",
+          "type": "platform"
+        }
+      }
+    },
+    "net452": {
+
+    } 
+  },
+
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
+  },
+
+  "publishOptions": {
+    "include": [
+      "wwwroot",
+      "**/*.cshtml",
+      "appsettings.json",
+      "web.config"
+    ]
+  },
+
+  "scripts": {
+    "postpublish": [ "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%" ]
+  }
+}

--- a/demos/Cimpress.Nancy.Security.Demo/web.config
+++ b/demos/Cimpress.Nancy.Security.Demo/web.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!--
+    Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
+  -->
+
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Creates a security example - uses the default 0Auth2 validator.

I had to remove the Virtual Member Calls from the base 0Auth2 validator so that the subclass could actually set those properties before they were used.