### PR TITLE
Fixes a null pointer exception with the content type header

### DIFF
--- a/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
+++ b/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
@@ -89,7 +89,7 @@ namespace Cimpress.Nancy.Logging
             var bodyString = new StreamReader(request.Body).ReadToEnd();
             request.Body.Position = 0;
 
-            var isBodyJson = string.Equals(request.Headers.ContentType, "application/json", StringComparison.OrdinalIgnoreCase);
+            var isBodyJson = string.Equals(request.Headers.ContentType ?? string.Empty, "application/json", StringComparison.OrdinalIgnoreCase);
 
             var bodyObject = new object();
             try


### PR DESCRIPTION
This fixes a bug with the logging project when the ContentType header is set to null. 