### PR TITLE
Adds status code to log message

### DIFF
--- a/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
+++ b/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
@@ -62,6 +62,8 @@ namespace Cimpress.Nancy.Logging
             logData["Host"] = Environment.MachineName;
             logData["Body"] = bodyObject;
             logData["CallDuration"] = duration;
+            logData["StatusCode"] = response.StatusCode;
+            logData["ResponseReason"] = response.ReasonPhrase;
 
             _logger.Info(new BaseMessage
             {


### PR DESCRIPTION
I noticed that the response log messages weren't recording the status codes. This quickly adds them.