### PR TITLE
Updates logging to use config and sumologic to use POST

### DIFF
--- a/demos/Cimpress.Nancy.Demo/DemoLogger.cs
+++ b/demos/Cimpress.Nancy.Demo/DemoLogger.cs
@@ -6,10 +6,6 @@ namespace Cimpress.Nancy.Demo
 {
     public class DemoLogger : INancyLogger
     {
-        public void Configure(IDictionary<string, string> options)
-        {
-
-        }
 
         public void Debug(object data)
         {

--- a/src/Cimpress.Nancy.Logging/SumologicAppender.cs
+++ b/src/Cimpress.Nancy.Logging/SumologicAppender.cs
@@ -42,7 +42,7 @@ namespace Cimpress.Nancy.Logging
                     }
                 }
 
-                _httpClient.GetAsync(_sumoLogicBaseUri + body);
+                _httpClient.PostAsync(_sumoLogicBaseUri, new StringContent(body));
             });
         }
     }

--- a/src/Cimpress.Nancy.Logging/SumologicLogger.cs
+++ b/src/Cimpress.Nancy.Logging/SumologicLogger.cs
@@ -3,23 +3,28 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Cimpress.Nancy.Components;
+using Cimpress.Nancy.Config;
 using log4net;
 
 namespace Cimpress.Nancy.Logging
 {
     public class SumologicLogger : INancyLogger
     {
+        public static readonly string ApplicationNameConfigKey = "ApplicationName";
+        public static readonly string EnvironmentNameConfigKey = "EnvironmentName";
+        public static readonly string SumologicBaseUriConfigKey = "SumologicBaseUri";
+
         private ILog _logger;
 
         private string _applicationName;
         private string _environmentName;
         private string _sumoLogicBaseUri;
 
-        public void Configure(IDictionary<string, string> options)
+        public SumologicLogger(IConfiguration configuration)
         {
-            var result = options.TryGetValue("ApplicationName", out _applicationName);
-            result &= options.TryGetValue("EnvironmentName", out _environmentName);
-            result &= options.TryGetValue("LoggingBaseUri", out _sumoLogicBaseUri);
+            var result = configuration.OptionalParameters.TryGetValue(ApplicationNameConfigKey, out _applicationName);
+            result &= configuration.OptionalParameters.TryGetValue(EnvironmentNameConfigKey, out _environmentName);
+            result &= configuration.OptionalParameters.TryGetValue(SumologicBaseUriConfigKey, out _sumoLogicBaseUri);
 
             if (!result)
             {
@@ -30,12 +35,12 @@ namespace Cimpress.Nancy.Logging
             SetJsonAppender();
 
             var envName = $"{_applicationName}.{_environmentName}";
-            var leLogger = LogManager.GetLogger(_applicationName, envName);
-            leLogger.Info(new BaseMessage
+            var logger = LogManager.GetLogger(_applicationName, envName);
+            logger.Info(new BaseMessage
             {
                 Message = "Service started at " + DateTime.Now
             });
-            _logger = leLogger;
+            _logger = logger;
         }
 
         public void Debug(object data)

--- a/src/Cimpress.Nancy/Components/INancyLogger.cs
+++ b/src/Cimpress.Nancy/Components/INancyLogger.cs
@@ -7,7 +7,6 @@ namespace Cimpress.Nancy.Components
 {
     public interface INancyLogger
     {
-        void Configure(IDictionary<string, string> options);
         void Debug(object data);
         void Info(object data);
         void Error(object data);

--- a/src/Cimpress.Nancy/Components/NoopLogger.cs
+++ b/src/Cimpress.Nancy/Components/NoopLogger.cs
@@ -7,9 +7,6 @@ namespace Cimpress.Nancy.Components
 {
     public class NoopLogger : INancyLogger
     {
-        public void Configure(IDictionary<string, string> options)
-        {
-        }
 
         public void Debug(object data)
         {

--- a/src/Cimpress.Nancy/NancyServiceBootstrapper.cs
+++ b/src/Cimpress.Nancy/NancyServiceBootstrapper.cs
@@ -21,21 +21,6 @@ namespace Cimpress.Nancy
         {
         }
 
-        public virtual string SumoLogicBaseUri
-        {
-            get { return string.Empty; }
-        }
-
-        public virtual string ApplicationName
-        {
-            get { return string.Empty; }
-        }
-
-        public virtual string EnvironmentName
-        {
-            get { return string.Empty; }
-        }
-
         protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
         {
             _componentManager = container.Resolve<IComponentManager>();


### PR DESCRIPTION
*Updates logging*
- I think I created this project before the `IConfiguration` object was usable, so I did some weird things to pass config options into the logger. It now uses the configuration object's optional parameters. 
- The Sumologic logger now puts the data in a `POST` instead of in the query parameters of a `GET`.
- There's now an optional character limit on the length a Request/Response body that will be logged. If not specified or not a positive integer, no limit will be enforced. If a positive int is entered, any body over that limit will be amputated. If the value is zero, the body effectively will not be logged.

This should not affect much, besides:
- Anyone using the SumoLogic logger will need to pass their config values into the IConfiguation.OptionalParameters object instead of storing it in the bootstrapper. I removed these values from the bootstrapper, so it will be obvious they are not used anymore.
- If anyone defined their own logger, the `Configure` function on the interface is not available anymore. The function was for passing the config values, but now you should be able to get the IConfiguration object injected into the constructor instead. 