### PR TITLE
Adds alpha suffix to project files

### DIFF
--- a/nugetPackage.bat
+++ b/nugetPackage.bat
@@ -1,6 +1,6 @@
 echo %APPVEYOR_BUILD_NUMBER%
 
-dotnet pack src/Cimpress.Nancy --configuration Release --version-suffix "alpha"
-dotnet pack src/Cimpress.Nancy.Logging --configuration Release --version-suffix "alpha"
-dotnet pack src/Cimpress.Nancy.Security --configuration Release --version-suffix "alpha"
-dotnet pack src/Cimpress.Nancy.Swagger --configuration Release --version-suffix "alpha"
+dotnet pack src/Cimpress.Nancy --configuration Release
+dotnet pack src/Cimpress.Nancy.Logging --configuration Release
+dotnet pack src/Cimpress.Nancy.Security --configuration Release
+dotnet pack src/Cimpress.Nancy.Swagger --configuration Release

--- a/src/Cimpress.Nancy.Logging/Cimpress.Nancy.Logging.csproj
+++ b/src/Cimpress.Nancy.Logging/Cimpress.Nancy.Logging.csproj
@@ -4,6 +4,7 @@
     <Description>An additional library to handle logging for Cimpress.Nancy</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>1.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Copyright>Cimpress 2017</Copyright>
     <AssemblyTitle>Cimpress.Nancy.Logging</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/Cimpress.Nancy.Security/Cimpress.Nancy.Security.csproj
+++ b/src/Cimpress.Nancy.Security/Cimpress.Nancy.Security.csproj
@@ -4,6 +4,7 @@
     <Description>An additional library to handle security for Cimpress.Nancy</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>1.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Copyright>Cimpress 2017</Copyright>
     <AssemblyTitle>Cimpress.Nancy.Security</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/Cimpress.Nancy.Swagger/Cimpress.Nancy.Swagger.csproj
+++ b/src/Cimpress.Nancy.Swagger/Cimpress.Nancy.Swagger.csproj
@@ -4,6 +4,7 @@
     <Description>An additional library to handle Swagger output for Cimpress.Nancy</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>1.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Copyright>Cimpress 2017</Copyright>
     <AssemblyTitle>Cimpress.Nancy.Swagger</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/Cimpress.Nancy/Cimpress.Nancy.csproj
+++ b/src/Cimpress.Nancy/Cimpress.Nancy.csproj
@@ -4,6 +4,7 @@
     <Description>A helper library for handling reproducible tasks such as logging and authentication for Nancy microservices</Description>
     <APPVEYOR_BUILD_NUMBER Condition="'$(APPVEYOR_BUILD_NUMBER)' == ''">1</APPVEYOR_BUILD_NUMBER>
     <VersionPrefix>1.0.$(APPVEYOR_BUILD_NUMBER)</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Copyright>Cimpress 2017</Copyright>
     <AssemblyTitle>Cimpress.Nancy</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
Fixes #35 
Moves the alpha prefix to the project files, so that the nuget packages are generated properly. 

You should deploy a new version after this.