### PR TITLE
Logs query params and hides authorization from logs

### DIFF
--- a/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
+++ b/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
@@ -120,9 +120,13 @@ namespace Cimpress.Nancy.Logging
                 isBodyJson = false;
             }
 
+            var query = (IDictionary<string, object>)context.Request.Query;
+            var queryLog = query.Select(kv => new KeyValuePair<string, string>(kv.Key, kv.Value.ToString()));
+
             logData["Host"] = Environment.MachineName;
             logData["Form"] = JsonConvert.DeserializeObject(formString);
             logData["Headers"] = request.Headers;
+            logData["Query"] = queryLog;
             logData["Body"] = isBodyJson ? bodyObject : bodyString;
             logData["Method"] = request.Method;
 

--- a/src/Cimpress.Nancy.Security/OAuth2Validator.cs
+++ b/src/Cimpress.Nancy.Security/OAuth2Validator.cs
@@ -59,11 +59,13 @@ namespace Cimpress.Nancy.Security
             string jwt = string.Empty;
             try
             {
-                jwt = ctx.Request.Headers["Authorization"].FirstOrDefault() ?? string.Empty;
+                jwt = ctx.Request.Headers.Authorization ?? string.Empty;
                 if (jwt.StartsWith(Bearer))
                 {
                     jwt = jwt.Substring(Bearer.Length);
                 }
+                //The Authorization header value should be removed, so it won't be logged
+                ctx.Request.Headers.Authorization = "...obscured...";
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The query params are logged. 

And the Authorization header value is obscured. 