### PR TITLE
Allows auth0 v2 tokens to be verified

### DIFF
--- a/demos/Cimpress.Nancy.Security.Demo/DemoNancyServiceBootstrapper.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/DemoNancyServiceBootstrapper.cs
@@ -19,7 +19,9 @@ namespace Cimpress.Nancy.Security.Demo
             {
                 ["OAuth2Issuer"] = "[Pass root url of issuer here]",
                 ["OAuth2SecretKey"] = "[Pass application's secret key here]",
-                ["OAuth2ClientId"] = "[Pass application's client id here]"
+                ["OAuth2ClientId"] = "[Pass application's client id here]",
+                ["OAuth2JwksLocation"] = "[Pass auth0 tenant's jwks url here]",
+                ["OAuth2JwksAudience"] = "[Pass auth0 tenant's audience here]"
             };
             container.Register(configuration);
             base.ApplicationStartup(container, pipelines);

--- a/demos/Cimpress.Nancy.Security.Demo/Security/AuthValidator.cs
+++ b/demos/Cimpress.Nancy.Security.Demo/Security/AuthValidator.cs
@@ -14,10 +14,14 @@ namespace Cimpress.Nancy.Security.Demo.Security
             OAuth2Issuer = config.OptionalParameters["OAuth2Issuer"];
             OAuthSecretKey = config.OptionalParameters["OAuth2SecretKey"];
             OAuth2ClientId = config.OptionalParameters["OAuth2ClientId"];
+            OAuth2JwksLocation = config.OptionalParameters["OAuth2JwksLocation"];
+            OAuth2JwksAudience = config.OptionalParameters["OAuth2JwksAudience"];
         }
 
         public override string OAuth2Issuer { get; }
         public override string OAuthSecretKey { get; }
         public override string OAuth2ClientId { get; }
+        public override string OAuth2JwksLocation { get; }
+        public override string OAuth2JwksAudience { get; }
     }
 }

--- a/src/Cimpress.Nancy.Security/Data/JwksFile.cs
+++ b/src/Cimpress.Nancy.Security/Data/JwksFile.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cimpress.Nancy.Security.Data
+{
+    public class JwksFile
+    {
+        public List<JwksKey> Keys;
+    }
+}

--- a/src/Cimpress.Nancy.Security/Data/JwksKey.cs
+++ b/src/Cimpress.Nancy.Security/Data/JwksKey.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cimpress.Nancy.Security.Data
+{
+    public class JwksKey
+    {
+        public List<string> X5C;
+    }
+}


### PR DESCRIPTION
Fixes #40 

This allows Cimpress.Nancy services to use V1 and V2 access tokens. 

The two new configuration values would be like:

                ["OAuth2JwksLocation"] = "https://[company].auth0.com/.well-known/jwks.json",
                ["OAuth2JwksAudience"] = "https://api.[company].io/"

With this change, the first call to the service will cause an extra HTTP call, but the data will be cached after that.