### PR TITLE
Do not access the memory stream after closing the StreamReader.

### DIFF
--- a/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
+++ b/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
@@ -101,13 +101,14 @@ namespace Cimpress.Nancy.Logging
             var request = context.Request;
 
             var formString = JsonConvert.SerializeObject(request.Form.ToDictionary());
-            request.Body.Position = 0;
+
             string bodyString;
             using (var streamReader = new StreamReader(request.Body))
             {
+                request.Body.Position = 0;
                 bodyString = streamReader.ReadToEnd();
+                request.Body.Position = 0;
             }
-            request.Body.Position = 0;
 
             var isBodyJson = string.Equals(request.Headers.ContentType ?? string.Empty, "application/json", StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
This causes the error:
System.ObjectDisposedException: Cannot access a closed file.
   at System.IO.FileStream.get_Length()
   at Nancy.IO.RequestStream.set_Position(Int64 value)
   at Cimpress.Nancy.Logging.LoggingBootstrapperExtender.OnBeforeRequest(NancyContext context, IDictionary`2 logData)
   at Cimpress.Nancy.NancyServiceBootstrapper.OnBeforeRequest(NancyContext ctx)
   at Nancy.BeforePipeline.<>c__DisplayClass8_0.<Wrap>b__0(NancyContext ctx, CancellationToken ct)
   at Nancy.BeforePipeline.<Invoke>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Nancy.NancyEngine.<InvokeRequestLifeCycle>d__22.MoveNext()