### PR TITLE
Updates appveyor URLs in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cimpress.Nancy  [![Build status](https://ci.appveyor.com/api/projects/status/1o48qd7xf8wp1gy2?svg=true)](https://ci.appveyor.com/project/yahehe/cimpress-nancy)
+# Cimpress.Nancy  [![Build status](https://ci.appveyor.com/project/jnallard/cimpress-nancy/branch/master)](https://ci.appveyor.com/project/jnallard/cimpress-nancy)
 
 A library to help build NancyFx microservices. Handles things like logging of requests/responses/errors, authentication and authorization, swagger, etc.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cimpress.Nancy  [![Build status](https://ci.appveyor.com/project/jnallard/cimpress-nancy/branch/master)](https://ci.appveyor.com/project/jnallard/cimpress-nancy)
+# Cimpress.Nancy  [![Build status](https://ci.appveyor.com/api/projects/status/xixa1rxtgbdq2339/branch/master?svg=true)](https://ci.appveyor.com/project/jnallard/cimpress-nancy/branch/master)
 
 A library to help build NancyFx microservices. Handles things like logging of requests/responses/errors, authentication and authorization, swagger, etc.
 


### PR DESCRIPTION
Updates the Appveyor URL in the readme.
(I'm also checking the deployment process, since I finally got around to fixing the Nuget stuff).

Fixes #45 