### PR TITLE
Consolidates logging to one message per request and adds NancyContextLogger

### DIFF
--- a/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
+++ b/src/Cimpress.Nancy.Logging/LoggingBootstrapperExtender.cs
@@ -71,10 +71,12 @@ namespace Cimpress.Nancy.Logging
                 bodyObject = responseBody.Substring(0, _loggedBodySizeLimit);
             }
 
-            logData["Host"] = Environment.MachineName;
-            logData["Body"] = bodyObject;
-            logData["StatusCode"] = response.StatusCode;
-            logData["ResponseReason"] = response.ReasonPhrase;
+            logData["Response"] = new Dictionary<string, object>
+            {
+                { "Body", bodyObject },
+                { "StatusCode", response.StatusCode },
+                { "Reason", response.ReasonPhrase },
+            };
 
             _logger.Info(new BaseMessage
             {
@@ -123,19 +125,15 @@ namespace Cimpress.Nancy.Logging
             var query = (IDictionary<string, object>)context.Request.Query;
             var queryLog = query.Select(kv => new KeyValuePair<string, string>(kv.Key, kv.Value.ToString()));
 
-            logData["Host"] = Environment.MachineName;
-            logData["Form"] = JsonConvert.DeserializeObject(formString);
-            logData["Headers"] = request.Headers;
-            logData["Query"] = queryLog;
-            logData["Body"] = isBodyJson ? bodyObject : bodyString;
-            logData["Method"] = request.Method;
-
-            _logger.Debug(new BaseMessage
+            logData["Request"] = new Dictionary<string, object>
             {
-                Message = request.Path,
-                CorrelationId = correlationId,
-                Info = logData
-            });
+                { "Host", Environment.MachineName },
+                { "Form", JsonConvert.DeserializeObject(formString) },
+                { "Headers", request.Headers },
+                { "Query", queryLog },
+                { "Body", isBodyJson ? bodyObject : bodyString },
+                { "Method", request.Method },
+            };
             return null;
         }
 

--- a/src/Cimpress.Nancy.Logging/NancyContextLogger.cs
+++ b/src/Cimpress.Nancy.Logging/NancyContextLogger.cs
@@ -1,0 +1,87 @@
+﻿using Nancy;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Cimpress.Nancy.Logging
+{
+    public class NancyContextLogger
+    {
+        private const string DurationsKey = "Durations";
+        private const string MetadataKey = "Metadata";
+
+        private readonly ConcurrentDictionary<string, long> _durations;
+        private readonly ConcurrentDictionary<string, object> _metadata;
+
+        public NancyContextLogger(NancyContext context)
+        {
+            var logData = NancyServiceBootstrapper.GetLogData(context);
+
+            if (!logData.ContainsKey(DurationsKey))
+            {
+                logData[DurationsKey] = new ConcurrentDictionary<string, long>();
+            }
+            _durations = (ConcurrentDictionary<string, long>) logData[DurationsKey];
+
+            if (!logData.ContainsKey(MetadataKey))
+            {
+                logData[MetadataKey] = new ConcurrentDictionary<string, object>();
+            }
+            _metadata = (ConcurrentDictionary<string, object>) logData[MetadataKey];
+        }
+
+        public void AddMetadata(string key, object value)
+        {
+            _metadata[key] = value;
+        }
+
+        public void LogDuration(Action action, string operation)
+        {
+            LogDuration(() => { action(); return 0; }, operation);
+        }
+
+        public T LogDuration<T>(Func<T> myFunc, string operation)
+        {
+            var sw = Stopwatch.StartNew();
+            T result;
+            try
+            {
+                result = myFunc();
+            }
+            finally
+            {
+                _durations[operation] = sw.ElapsedMilliseconds;
+            }
+            return result;
+        }
+
+        public async Task<T> LogDuration<T>(Task<T> task, string operation)
+        {
+            var sw = Stopwatch.StartNew();
+            T result;
+            try
+            {
+                result = await task.ConfigureAwait(false);
+            }
+            finally
+            {
+                _durations[operation] = sw.ElapsedMilliseconds;
+            }
+            return result;
+        }
+
+        public async Task LogDuration(Task task, string operation)
+        {
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            finally
+            {
+                _durations[operation] = sw.ElapsedMilliseconds;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will have the Request and the Response/Error logged in the same log message.

It also provides the ability to log metadata and durations from a Nancy Module.

(I took the methods for logging duration from Legacyplant)